### PR TITLE
Replace `HCT` with `Hct` in README.md

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -15,10 +15,10 @@ for more information.
 `npm i @material/material-color-utilities` or `yarn add @material/material-color-utilities`
 
 ```typescript
-import { HCT } from "@material/material-color-utilities";
+import { Hct } from "@material/material-color-utilities";
 
-// Simple demonstration of HCT.
-const color = HCT.fromInt(0xff4285f4);
+// Simple demonstration of Hct.
+const color = Hct.fromInt(0xff4285f4);
 console.log(`Hue: ${color.hue}`);
 console.log(`Chrome: ${color.chroma}`);
 console.log(`Tone: ${color.tone}`);


### PR DESCRIPTION
Just fixed the typo in TypeScript's README.